### PR TITLE
Add a new shader - 3D Vertical Dissolve in Object Space

### DIFF
--- a/Dissolve/3D Vertical Dissolve Object Space.shader
+++ b/Dissolve/3D Vertical Dissolve Object Space.shader
@@ -1,0 +1,62 @@
+shader_type spatial;
+render_mode cull_disabled;
+
+uniform sampler2D texture;
+uniform sampler2D blendTexture;
+uniform sampler2D noiseTexture;
+
+uniform float offset = 0.;
+uniform bool up = true;
+uniform vec4 borderColor: hint_color = vec4(1., 1., 0., 1.);
+uniform float borderHeight = 0.1;
+uniform float waveAmplitude = 1.;
+uniform float waveFrequency = 1.;
+uniform float wavePhase = 0.1;
+uniform float emissionIntensity = 1.;
+uniform float noiseSpeed = .01;
+uniform float noiseInfluence = 1.;
+
+uniform vec2 blendUVScale = vec2(1.);
+uniform vec2 noiseUVScale = vec2(1.);
+uniform vec2 textureUVScale = vec2(1.);
+
+const float tao = 2. * 3.14;
+
+varying vec3 world_pos;
+
+void fragment() {
+	vec3 position = (inverse(WORLD_MATRIX) * CAMERA_MATRIX * vec4(VERTEX, 1.0)).xyz;
+	vec4 text = texture(texture, UV);
+	vec4 blend = texture(blendTexture, UV * blendUVScale);
+
+	vec2 st = UV;
+	st.y -= TIME * noiseSpeed;
+	vec4 noise = texture(noiseTexture, st * noiseUVScale);
+
+	float x = tao * position.x;
+	float waveFrequency1 = waveFrequency;
+	float waveFrequency2 = waveFrequency + 2. - wavePhase;
+	float waveFrequency3 = waveFrequency + 3. - wavePhase;
+	
+	position.y += waveAmplitude * (sin(x / waveFrequency1) + sin(x / waveFrequency2) + sin(x / waveFrequency3));
+	position.y += (noise.r * noiseInfluence);
+
+	float direction = up ? 1. : -1.;
+	float upperBorder = smoothstep(offset, offset, (position.y * direction) + 1.);
+	float bottomBorder = smoothstep(offset, offset, (position.y * direction) - borderHeight + 1.);
+	float borderPart = upperBorder - bottomBorder;
+
+	vec4 color = mix(blend, borderColor, upperBorder);
+	color = mix(color, text, bottomBorder);
+	
+	ALBEDO = color.rgb;
+
+	if (!FRONT_FACING) {
+		ALBEDO = borderColor.rgb;
+		NORMAL = VIEW;
+	}
+
+	ALPHA = color.a;
+	ALPHA_SCISSOR = 1.0;
+	EMISSION = vec3(borderPart) * borderColor.rgb * emissionIntensity;
+}

--- a/Dissolve/3D Vertical Dissolve Object Space.tscn
+++ b/Dissolve/3D Vertical Dissolve Object Space.tscn
@@ -1,0 +1,99 @@
+[gd_scene load_steps=15 format=2]
+
+[ext_resource path="res://resources/texture2.png" type="Texture" id=1]
+[ext_resource path="res://resources/texture1.png" type="Texture" id=2]
+[ext_resource path="res://resources/transparent.png" type="Texture" id=3]
+[ext_resource path="res://Dissolve/3D Vertical Dissolve.gd" type="Script" id=4]
+[ext_resource path="res://resources/suzanne.obj" type="ArrayMesh" id=5]
+[ext_resource path="res://resources/noise.tres" type="OpenSimplexNoise" id=6]
+[ext_resource path="res://Dissolve/3D Vertical Dissolve Object Space.shader" type="Shader" id=8]
+
+[sub_resource type="NoiseTexture" id=1]
+noise = ExtResource( 6 )
+
+[sub_resource type="ShaderMaterial" id=8]
+shader = ExtResource( 8 )
+shader_param/offset = -2.25146
+shader_param/up = false
+shader_param/borderColor = Color( 1, 1, 0, 1 )
+shader_param/borderHeight = 0.05
+shader_param/waveAmplitude = 0.05
+shader_param/waveFrequency = 1.0
+shader_param/wavePhase = 6.0
+shader_param/emissionIntensity = 1.0
+shader_param/noiseSpeed = 0.05
+shader_param/noiseInfluence = 1.0
+shader_param/blendUVScale = Vector2( 1, 1 )
+shader_param/noiseUVScale = Vector2( 1, 1 )
+shader_param/textureUVScale = Vector2( 1, 1 )
+shader_param/texture = ExtResource( 2 )
+shader_param/blendTexture = ExtResource( 1 )
+shader_param/noiseTexture = SubResource( 1 )
+
+[sub_resource type="ShaderMaterial" id=9]
+shader = ExtResource( 8 )
+shader_param/offset = -2.25146
+shader_param/up = false
+shader_param/borderColor = Color( 1, 1, 0, 1 )
+shader_param/borderHeight = 0.05
+shader_param/waveAmplitude = 0.05
+shader_param/waveFrequency = 1.0
+shader_param/wavePhase = 6.0
+shader_param/emissionIntensity = 1.0
+shader_param/noiseSpeed = 0.05
+shader_param/noiseInfluence = 0.5
+shader_param/blendUVScale = Vector2( 1, 1 )
+shader_param/noiseUVScale = Vector2( 1, 1 )
+shader_param/textureUVScale = Vector2( 1, 1 )
+shader_param/texture = ExtResource( 2 )
+shader_param/blendTexture = ExtResource( 3 )
+shader_param/noiseTexture = SubResource( 1 )
+
+[sub_resource type="ProceduralSky" id=4]
+
+[sub_resource type="Environment" id=5]
+background_mode = 3
+background_sky = SubResource( 4 )
+background_color = Color( 0.533333, 0.52549, 0.52549, 1 )
+fog_enabled = true
+ssao_enabled = true
+glow_enabled = true
+
+[sub_resource type="SpatialMaterial" id=6]
+albedo_color = Color( 0.580392, 0.592157, 0.603922, 1 )
+
+[sub_resource type="PlaneMesh" id=7]
+size = Vector2( 400, 400 )
+
+[node name="3DVerticalDissolveObjectSpace" type="Spatial"]
+script = ExtResource( 4 )
+testShader = true
+speed = 2.0
+from = 2.0
+to = 3.0
+
+[node name="Suzanne1" type="MeshInstance" parent="."]
+transform = Transform( -0.290589, -0.955637, 0.0481307, -0.468944, 0.098389, -0.87773, 0.834056, -0.277629, -0.47673, 3.38258, 0, -0.0491965 )
+mesh = ExtResource( 5 )
+material/0 = SubResource( 8 )
+
+[node name="Suzanne2" type="MeshInstance" parent="."]
+transform = Transform( 0.834303, 0.422931, -0.353649, 0.0807726, -0.728325, -0.680455, -0.545356, 0.539141, -0.641805, -2.47355, 0.0160527, -0.155344 )
+mesh = ExtResource( 5 )
+material/0 = SubResource( 9 )
+
+[node name="DirectionalLight" type="DirectionalLight" parent="."]
+transform = Transform( 1, 0, 0, 0, 0.821189, 0.570656, 0, -0.570656, 0.821189, 0, 21.5684, 30.6121 )
+light_energy = 2.0
+shadow_enabled = true
+directional_shadow_mode = 0
+
+[node name="Camera" type="Camera" parent="."]
+transform = Transform( 1, 0, 0, 0, 0.933612, 0.358287, 0, -0.358287, 0.933612, 0, 2.002, 5.979 )
+environment = SubResource( 5 )
+far = 167.2
+
+[node name="Plane" type="MeshInstance" parent="."]
+transform = Transform( 1, 0, 0, 0, 0.935869, -0.352348, 0, 0.352348, 0.935869, 0, -13.2698, -12.6181 )
+material_override = SubResource( 6 )
+mesh = SubResource( 7 )


### PR DESCRIPTION
This shader uses the same code from the "3D Vertical Dissolve" shader, but instead of taking the object's global_transform, it uses the object pixel in local space to dissolve, this way, it dissolves from the mesh's real local top-down or bottom-up (for example, "from head to chin" or "from chin to head").

The only change is in `vec3 position = (inverse(WORLD_MATRIX) * CAMERA_MATRIX * vec4(VERTEX, 1.0)).xyz;` instead of `vec3 position = world_pos;`.

This is the final result:

https://user-images.githubusercontent.com/248383/182779141-0ab7425f-7bc0-43e5-9830-90f65e27c367.mp4

As a comparison, this is the behaviour of the existing 3D Vertical Dissolve shader, notice after 0:02 when I rotate the mesh, how it's dissolved (it doesn't take into consideration that the "top" is the "head"):

https://user-images.githubusercontent.com/248383/182779013-5e87dbc5-aafe-4ad9-a223-f8a6f13b8239.mp4


